### PR TITLE
enable text editor "Line spacing" feature in StructuredTextViewer

### DIFF
--- a/core/bundles/org.eclipse.wst.sse.ui/src/org/eclipse/wst/sse/ui/internal/StructuredTextViewer.java
+++ b/core/bundles/org.eclipse.wst.sse.ui/src/org/eclipse/wst/sse/ui/internal/StructuredTextViewer.java
@@ -298,6 +298,7 @@ public class StructuredTextViewer extends ProjectionViewer implements IDocumentS
 		}
 		setOverviewRulerAnnotationHover(configuration.getOverviewRulerAnnotationHover(this));
 
+		getTextWidget().setLineSpacing(configuration.getLineSpacing(this));
 		getTextWidget().setTabs(configuration.getTabWidth(this));
 		setHoverControlCreator(configuration.getInformationControlCreator(this));
 


### PR DESCRIPTION
The XML text editor did not take the "line spacing" functionality into account. This will be fixed with this change.