### PR TITLE
Use exclusively latest Orbit libraries

### DIFF
--- a/web/bundles/org.eclipse.jst.standard.schemas/META-INF/MANIFEST.MF
+++ b/web/bundles/org.eclipse.jst.standard.schemas/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: org.eclipse.jst.standard.schemas;singleton:=true
 Bundle-Version: 1.2.700.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
-Require-Bundle: jakarta.servlet;bundle-version="5.0.0"
+Require-Bundle: jakarta.servlet-api;bundle-version="5.0.0"

--- a/xml/features/org.eclipse.wst.xml_core.feature/feature.xml
+++ b/xml/features/org.eclipse.wst.xml_core.feature/feature.xml
@@ -31,9 +31,6 @@
       %license
    </license>
 
-   <plugin
-         id="javax.xml"
-         version="1.3.4.qualifier"/>
 
    <plugin
          id="org.apache.xml.resolver"

--- a/xpath/bundles/org.eclipse.wst.xml.xpath2.processor/META-INF/MANIFEST.MF
+++ b/xpath/bundles/org.eclipse.wst.xml.xpath2.processor/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wst.xml.xpath2.processor
 Bundle-Version: 2.2.0.qualifier
 Require-Bundle: org.apache.xerces;bundle-version="[2.12.0,3.0.0)",
- com.ibm.icu;bundle-version="73.1.0",
- java_cup-runtime;bundle-version="0.11.0"
+ com.ibm.icu;bundle-version="73.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.wst.xml.xpath2.api,
  org.eclipse.wst.xml.xpath2.api.typesystem,
@@ -22,5 +21,6 @@ Export-Package: org.eclipse.wst.xml.xpath2.api,
  org.eclipse.wst.xml.xpath2.processor.internal.types.xerces;x-internal:=true,
  org.eclipse.wst.xml.xpath2.processor.internal.utils;x-internal:=true,
  org.eclipse.wst.xml.xpath2.processor.util
+Import-Package: java_cup.runtime;version="2.7.2"
 Bundle-Vendor: %provider
 Bundle-Localization: plugin

--- a/xpath/features/org.eclipse.wst.xml.xpath2.processor.feature/feature.xml
+++ b/xpath/features/org.eclipse.wst.xml.xpath2.processor.feature/feature.xml
@@ -58,12 +58,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="java_cup-runtime"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.wst.xml.xpath2.processor.doc.user"
          download-size="0"
          install-size="0"

--- a/xpath/tests/org.eclipse.wst.xml.xpath2.processor.tests/META-INF/MANIFEST.MF
+++ b/xpath/tests/org.eclipse.wst.xml.xpath2.processor.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.apache.xerces;bundle-version="[2.9.0,3.0.0)",
  org.junit;bundle-version="3.8.2",
  org.w3c.xqts.testsuite;bundle-version="1.0.2",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",
- java_cup-runtime;bundle-version="0.11.0",
  com.ibm.icu
 Export-Package: org.custommonkey.xmlunit,
  org.custommonkey.xmlunit.examples,
@@ -26,6 +25,7 @@ Export-Package: org.custommonkey.xmlunit,
  org.eclipse.wst.xml.xpath2.processor.testsuite.numeric,
  org.eclipse.wst.xml.xpath2.processor.testsuite.schema,
  org.eclipse.wst.xml.xpath2.processor.testsuite.userdefined
+Import-Package: java_cup.runtime
 Bundle-Activator: org.eclipse.wst.xml.xpath2.processor.test.XPath20TestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,

--- a/xsl/features/org.eclipse.wst.xsl.feature/feature.xml
+++ b/xsl/features/org.eclipse.wst.xsl.feature/feature.xml
@@ -38,8 +38,6 @@
       <import plugin="org.apache.xalan" version="0.0.0" match="greaterOrEqual"/>
       <import plugin="org.apache.commons.commons-logging" version="1.0.4" match="greaterOrEqual"/>
       <import plugin="org.apache.xml.serializer" version="0.0.0" match="greaterOrEqual"/>
-      <import plugin="org.apache.bcel" version="0.0.0" match="greaterOrEqual"/>
-      <import plugin="java_cup-runtime" version="0.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
- javax.xml delete
- java_cup-runtime delete - available in org.apache.xalan
- org.apache.bcel delete - not needed

https://github.com/eclipse-simrel/simrel.build/issues/438