### PR TITLE
Avoid using the bundle name org.apache.commons.commons-logging

### DIFF
--- a/xsl/bundles/org.eclipse.wst.xsl.jaxp.debug/META-INF/MANIFEST.MF
+++ b/xsl/bundles/org.eclipse.wst.xsl.jaxp.debug/META-INF/MANIFEST.MF
@@ -5,9 +5,9 @@ Bundle-SymbolicName: org.eclipse.wst.xsl.jaxp.debug;singleton:=true
 Bundle-Version: 1.1.200.qualifier
 Bundle-Vendor: %vendorName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.apache.commons.commons-logging;bundle-version="1.0.4";visibility:=reexport,
- org.apache.xml.resolver;bundle-version="1.1.0";resolution:=optional
+Require-Bundle: org.apache.xml.resolver;bundle-version="1.1.0";resolution:=optional
 Export-Package: org.eclipse.wst.xsl.jaxp.debug.debugger,
  org.eclipse.wst.xsl.jaxp.debug.invoker,
  org.eclipse.wst.xsl.jaxp.debug.invoker.internal;x-internal:=true
+Import-Package: org.apache.commons.logging;version="[1.2.0,2.0.0)"
 Bundle-Localization: plugin

--- a/xsl/bundles/org.eclipse.wst.xsl.xalan/META-INF/MANIFEST.MF
+++ b/xsl/bundles/org.eclipse.wst.xsl.xalan/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Export-Package: org.eclipse.wst.xsl.xalan.debugger;
    org.apache.xalan.trace,
    javax.xml.transform,
    org.apache.xalan.templates"
+Import-Package: org.apache.commons.logging;version="[1.2.0,2.0.0)"
 Require-Bundle: org.apache.xalan;bundle-version="[2.7.0,2.8.0)",
  org.apache.xml.serializer;bundle-version="[2.7.0,2.8.0)",
  org.eclipse.wst.xsl.jaxp.debug;bundle-version="[1.0.0,2.0.0)";resolution:=optional

--- a/xsl/features/org.eclipse.wst.xsl.feature/feature.xml
+++ b/xsl/features/org.eclipse.wst.xsl.feature/feature.xml
@@ -36,7 +36,6 @@
       <import feature="org.eclipse.wst.xml.xpath2.processor.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.wst.xml_ui.feature" version="3.3.0" match="greaterOrEqual"/>
       <import plugin="org.apache.xalan" version="0.0.0" match="greaterOrEqual"/>
-      <import plugin="org.apache.commons.commons-logging" version="1.0.4" match="greaterOrEqual"/>
       <import plugin="org.apache.xml.serializer" version="0.0.0" match="greaterOrEqual"/>
       <import plugin="org.apache.bcel" version="0.0.0" match="greaterOrEqual"/>
       <import plugin="java_cup-runtime" version="0.0.0" match="greaterOrEqual"/>


### PR DESCRIPTION
- Rely purely on package imports of org.apache.commons.logging and include version 1.2.0 in the range.

https://github.com/eclipse-orbit/orbit-simrel/issues/40